### PR TITLE
Removed ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,3 @@ ENV PATH="${PATH}:/src/gcc-arm-none-eabi-9-2019-q4-major/bin"
 COPY --from=rust_build /usr/src/bestool/bestool/target/release/bestool /usr/local/bin/bestool
 COPY . /usr/src
 
-ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Removed the `ENTRYPOINT` line so that `./start_dev.sh` works. The `docker-compose.yml` seems to handle dropping into Bash already.

I did have to do a `docker-compose build` after checking out the new branch - might be worth running that command if the Docker build seems to be running on an old image like it was for me!