### PR TITLE
Remove "command: bash" line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     privileged: true
     build:
       context: .
-    command: /bin/bash
     volumes:
       - ./:/usr/src:Z
       - /dev/:/dev/


### PR DESCRIPTION
Removes the "command: bash" line so that ./start_dev.sh works. The Dockerfile ENTRYPOINT line now handles the entry into bash. This PR accomplishes the same thing as #1 - making `./start_dev.sh` work with the refactored Dockerfile. Only one of these PRs should be merged!